### PR TITLE
fix #13

### DIFF
--- a/cmd/data-prep/utils/carlet.go
+++ b/cmd/data-prep/utils/carlet.go
@@ -138,6 +138,11 @@ func SplitAndCommp(r io.Reader, targetSize int, output string) ([]CarFile, error
 			return carFiles, err
 		}
 
+		err = resetCP(cp)
+		if err != nil {
+			return carFiles, err
+		}
+
 		commCid, err := commcid.DataCommitmentV1ToCID(rawCommP)
 		if err != nil {
 			return carFiles, err
@@ -181,4 +186,12 @@ func discardHeader(streamBuf *bufio.Reader, streamLen int64) (int64, error) {
 	streamLen += actualHdrLen
 
 	return streamLen, nil
+}
+
+func resetCP(cp *commp.Calc) error {
+	cp.Reset()
+	_, err := cp.Write([]byte(nulRootCarHeader))
+	if err != nil {
+		return err
+	}
 }


### PR DESCRIPTION
```
anjor@seven data (anjor/tools)*$ ~/repos/anjor/go-fil-dataprep/cmd/data-prep/data-prep dp --size 1000000000 --output a --metadata test_meta.csv subdir
for i in {0..5}; do cat a-root cid = bafybeihsshuadcxukrkye76kfeci5mbs7v7o5iq32d2xhzygxnj6s7asw4
anjor@seven data (anjor/tools)*$ for i in {0..5}; do cat a-$i.car | stream-commp; done

CommPCid: baga6ea4seaqf5gm7otl2bnfhzpji7brxkk3jwom63pvo232okchammxc3y666li
Payload:          1000378736 bytes
Unpadded piece:   1065353216 bytes
Padded piece:     1073741824 bytes

CARv1 detected in stream:
Blocks:       954
Roots:          1
    1: bafkqaaa


CommPCid: baga6ea4seaqioi3eezjc6o3jzr4zkaiquqv7inn72s6e4pdebsrplhua7yn62li
Payload:          1000378736 bytes
Unpadded piece:   1065353216 bytes
Padded piece:     1073741824 bytes

CARv1 detected in stream:
Blocks:       954
Roots:          1
    1: bafkqaaa


CommPCid: baga6ea4seaqknb75ze4rpln3bhazk4outi2sqcufvr4euxsunnzdtc4mkaldmmq
Payload:          1000378736 bytes
Unpadded piece:   1065353216 bytes
Padded piece:     1073741824 bytes

CARv1 detected in stream:
Blocks:       954
Roots:          1
    1: bafkqaaa


CommPCid: baga6ea4seaqnmgymelbxsbj2liejtm3bj6amf2runvkpanrz7a4vsjzvnaqdkcq
Payload:          1000378736 bytes
Unpadded piece:   1065353216 bytes
Padded piece:     1073741824 bytes

CARv1 detected in stream:
Blocks:       954
Roots:          1
    1: bafkqaaa


CommPCid: baga6ea4seaqiilca4cgr2qb647c2n6jc4nns2cqlr5wjsjaddscrmr665c7veoa
Payload:          1000481186 bytes
Unpadded piece:   1065353216 bytes
Padded piece:     1073741824 bytes

CARv1 detected in stream:
Blocks:       955
Roots:          1
    1: bafkqaaa


CommPCid: baga6ea4seaqpjpeazdvnybsmllc3oq3ftnn626vlh7mg4rc5dnxgorlr4n7zcdi
Payload:           451062399 bytes
Unpadded piece:    532676608 bytes
Padded piece:      536870912 bytes

CARv1 detected in stream:
Blocks:       433
Roots:          1
    1: bafkqaaa

anjor@seven data (anjor/tools)*$ cat test_meta.csv
timestamp,original data,car file,root_cid,piece cid,padded piece size
2023-04-17T16:54:32Z,a,bafybeihsshuadcxukrkye76kfeci5mbs7v7o5iq32d2xhzygxnj6s7asw4,a-0.car,baga6ea4seaqf5gm7otl2bnfhzpji7brxkk3jwom63pvo232okchammxc3y666li,1073741824
2023-04-17T16:54:32Z,a,bafybeihsshuadcxukrkye76kfeci5mbs7v7o5iq32d2xhzygxnj6s7asw4,a-1.car,baga6ea4seaqioi3eezjc6o3jzr4zkaiquqv7inn72s6e4pdebsrplhua7yn62li,1073741824
2023-04-17T16:54:32Z,a,bafybeihsshuadcxukrkye76kfeci5mbs7v7o5iq32d2xhzygxnj6s7asw4,a-2.car,baga6ea4seaqknb75ze4rpln3bhazk4outi2sqcufvr4euxsunnzdtc4mkaldmmq,1073741824
2023-04-17T16:54:32Z,a,bafybeihsshuadcxukrkye76kfeci5mbs7v7o5iq32d2xhzygxnj6s7asw4,a-3.car,baga6ea4seaqnmgymelbxsbj2liejtm3bj6amf2runvkpanrz7a4vsjzvnaqdkcq,1073741824
2023-04-17T16:54:32Z,a,bafybeihsshuadcxukrkye76kfeci5mbs7v7o5iq32d2xhzygxnj6s7asw4,a-4.car,baga6ea4seaqiilca4cgr2qb647c2n6jc4nns2cqlr5wjsjaddscrmr665c7veoa,1073741824
2023-04-17T16:54:32Z,a,bafybeihsshuadcxukrkye76kfeci5mbs7v7o5iq32d2xhzygxnj6s7asw4,a-5.car,baga6ea4seaqpjpeazdvnybsmllc3oq3ftnn626vlh7mg4rc5dnxgorlr4n7zcdi,536870912
anjor@seven data (anjor/tools)*$
```