### PR TITLE
Return error code on failed exit

### DIFF
--- a/cmd/data-prep/main.go
+++ b/cmd/data-prep/main.go
@@ -19,6 +19,6 @@ func main() {
 	err := app.Run(os.Args)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
-		return
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Make sure main returns an error code on failure so that it's easier to integrate into batch scripts.