### PR TITLE
fix wrap dir

### DIFF
--- a/cmd/data-prep/fil-data-prep/fil-data-prep.go
+++ b/cmd/data-prep/fil-data-prep/fil-data-prep.go
@@ -100,8 +100,11 @@ func filDataPrep(c *cli.Context) error {
 			rcid = nodes[0].Cid() // use fake root directory if multiple args
 			writeNode(nodes, wout)
 		} else {
-			rcid = nodes[1].Cid() // otherwise use the first node (which should work)
-			writeNode(nodes[1:], wout)
+			path := paths[0]
+			splitPath := strings.Split(path, "/")
+			idx := len(splitPath)
+			rcid = nodes[idx].Cid() // otherwise use the first node (which should work)
+			writeNode(nodes[idx:], wout)
 		}
 	}()
 
@@ -151,15 +154,15 @@ func filDataPrep(c *cli.Context) error {
 }
 
 func writeNode(nodes []*merkledag.ProtoNode, wout *io.PipeWriter) {
-	var cid, sizeVi []byte
+	var c, sizeVi []byte
 	for _, nd := range nodes {
-		cid = []byte(nd.Cid().KeyString())
+		c = []byte(nd.Cid().KeyString())
 		d := nd.RawData()
 
-		sizeVi = appendVarint(sizeVi[:0], uint64(len(cid))+uint64(len(d)))
+		sizeVi = appendVarint(sizeVi[:0], uint64(len(c))+uint64(len(d)))
 
 		if _, err := wout.Write(sizeVi); err == nil {
-			if _, err := wout.Write(cid); err == nil {
+			if _, err := wout.Write(c); err == nil {
 				if _, err := wout.Write(d); err != nil {
 					fmt.Printf("failed to write car: %s\n", err)
 				}

--- a/cmd/data-prep/fil-data-prep/tree_utils.go
+++ b/cmd/data-prep/fil-data-prep/tree_utils.go
@@ -64,11 +64,11 @@ func (n *node) constructNode() {
 	n.size = size
 }
 
-func constructTree(paths []string, rs []roots) *node {
+func constructTree(files []string, rs []roots) *node {
 	root := newNode("root")
 
-	for i, path := range paths {
-		parts := strings.Split(path, "/")
+	for i, file := range files {
+		parts := strings.Split(file, "/")
 		currentNode := root
 
 		for _, part := range parts {


### PR DESCRIPTION
```
$ ~/repos/anjor/go-fil-dataprep/cmd/data-prep/data-prep dp --size 1000000000 --output o /Users/anjor/repos/filecoin-project/data-prep-tools/data/subdir2
root cid = bafybeibzqezcz5muy43cd6gh4voxbxx3fch46f7hchslxu37oyelaqkhiq
```

```
$ ls /Users/anjor/repos/filecoin-project/data-prep-tools/data/subdir2
a.txt		b.txt		subdir		test.txt
```

<img width="1194" alt="Screenshot 2023-07-08 at 10 31 29 PM" src="https://github.com/anjor/go-fil-dataprep/assets/1911631/51eb0572-0acc-42cb-8066-fd4ad07b9cb5">
